### PR TITLE
Extend .gitignore with ".directory" for kde users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ radiotools/atmosphere/constants*
 .settings/
 radiotools/doc/_build/
 radiotools/doc/copy_docs_to_cglaserde.sh
+
+# for kde users
+.directory


### PR DESCRIPTION
Kde creates annoying .directory files to store the configuration of the std file manager for each directory.