### PR TITLE
Continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - '2.7'
 cache: pip
 install:
-  - pip install numpy scipy unittest pickle matplotlib
+  - pip install numpy scipy matplotlib
 script:
   - python tests/tests_coordinatesystems.py
   - python tests/tests_atmosphere.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ cache: pip
 install:
   - pip install numpy scipy matplotlib
 script:
+  - echo Start Unittests for python 2.7 ...
+  - echo $PWD
+  - export PYTHONPATH=$PYTHONPATH:$PWD
   - python tests/tests_coordinatesystems.py
   - python tests/tests_atmosphere.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: python
 python:
   - '2.7'
+  - '3.6'
 cache: pip
 install:
   - pip install numpy scipy matplotlib
 script:
-  - echo Start Unittests for python 2.7 ...
-  - echo $PWD
   - export PYTHONPATH=$PYTHONPATH:$PWD
   - python tests/tests_coordinatesystems.py
   - python tests/tests_atmosphere.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,9 @@
 language: python
+python:
+  - '2.7'
+cache: pip
+install:
+  - pip install numpy scipy unittest pickle matplotlib
+script:
+  - python tests/tests_coordinatesystems.py
+  - python tests/tests_atmosphere.py

--- a/tests/tests_atmosphere.py
+++ b/tests/tests_atmosphere.py
@@ -3,8 +3,6 @@ from radiotools.atmosphere import models as atm
 import unittest
 import numpy as np
 
-# initilize atmosphere
-at = atm.Atmosphere(model=27)
 
 zen = np.deg2rad(70)
 xmax = 800.  # g/cm2
@@ -12,8 +10,9 @@ xmax = 800.  # g/cm2
 
 class AtmosphereTests(unittest.TestCase):
 
-    # this is a rather weak test checking if the observation_level is used in the calculation at all 
+    # this is a rather weak test checking if the observation_level is used in the calculation at all
     def test_geometric_distance_to_xmax_for_different_obs_lvl(self):
+        at = atm.Atmosphere()
         dxmax_0 = at.get_distance_xmax_geometric(zen, xmax, observation_level=0.)
         dxmax_1564 = at.get_distance_xmax_geometric(zen, xmax, observation_level=1564.)
         dxmax_3000 = at.get_distance_xmax_geometric(zen, xmax, observation_level=3000.)
@@ -23,4 +22,9 @@ class AtmosphereTests(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    try:
+        atm.Atmosphere()
+    except BaseException:
+        print "Initialized Atmosphere."
+
     unittest.main()

--- a/tests/tests_atmosphere.py
+++ b/tests/tests_atmosphere.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from radiotools.atmosphere import models as atm
 
 import unittest
@@ -25,6 +26,6 @@ if __name__ == "__main__":
     try:
         atm.Atmosphere()
     except BaseException:
-        print "Initialized Atmosphere."
+        print("Initialized Atmosphere.")
 
     unittest.main()

--- a/tests/tests_coordinatesystems.py
+++ b/tests/tests_coordinatesystems.py
@@ -21,7 +21,7 @@ v_xyz = -1 * np.array([np.sin(zenith) * np.cos(azimuth),
 v_vB_vvB2 = np.array([v_vB_vvB, 2 * v_vB_vvB])
 
 # test traces
-test_data = np.load("./test_data/efield_traces.npz", "r")
+test_data = np.load("tests/test_data/efield_traces.npz", "r")
 t_xyz = test_data["t_xyz"]
 t_vB_vvB = test_data["t_vBvvB"]
 


### PR DESCRIPTION
Hey,
With this pull request we add continuous integration for the radiotools.
Currently only simple test are performs, e.g., the project is build, dependencies installed, and the unittest scripts in tests/ are executed.
This is done for both python 2 and python 3!
At the moment the atmosphere test for python 3 is failing but that should be fixed with #16. However with the introduction of more tests (moved from the class file to the dedicated unittest script) #14 the last test will fail for python 2 and 3. This is due to a to high threshold for numeric calculations and can be fixed with lowering the limit to 80 deg #17.
Felix