### PR TITLE
Add class RefractivityTable. Allows fast calculation of the integrate…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@ ENV/
 # atmosphere files
 radiotools/atmosphere/constants*
 
+# refractivity files
+radiotools/atmosphere/refractivity_*npz
+
 .project
 .pydevproject
 .settings/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ script:
   - export PYTHONPATH=$PYTHONPATH:$PWD
   - python tests/tests_coordinatesystems.py
   - python tests/tests_atmosphere.py
+  - python tests/tests_refractivity.py

--- a/radiotools/atmosphere/refractivity.py
+++ b/radiotools/atmosphere/refractivity.py
@@ -1,0 +1,307 @@
+from radiotools.atmosphere import models as atm
+from radiotools import helper
+
+import numpy as np
+import sys
+import copy
+import os
+
+def n_param_ZHAireS(h):
+    a = 325e-6
+    b = 0.1218e-3
+    return 1 + a * np.exp(-b * h)
+
+
+class RefractivityTable(object):
+
+    def __init__(self, atm_model=atm.default_model, param=False, refractivity_at_sea_level=312e-6, curved=False,
+                 interpolate_zenith=True, number_of_zenith_bins=1000, distance_increment=100):
+
+        self._distance_increment = distance_increment
+        self._number_of_zenith_bins = number_of_zenith_bins
+        self._interpolate_zenith = interpolate_zenith
+        self._refractivity_at_sea_level = refractivity_at_sea_level
+        self._use_param = param
+        self._atm_model = atm_model
+        self._rho0 = atm.get_density(0, allow_negative_heights=False, model=self._atm_model)
+
+        self._height_increment = 10
+        self._heights = np.arange(0, 2e5, self._height_increment)
+        self._refractivity_table = np.zeros(len(self._heights))
+        for hdx, height in enumerate(self._heights):
+            if self._use_param:
+                refractivity = n_param_ZHAireS(height) - 1
+            else:
+                refractivity = self._refractivity_at_sea_level * \
+                    atm.get_density(height, allow_negative_heights=True, model=self._atm_model) / self._rho0
+
+            self._refractivity_table[hdx] = refractivity
+
+        self._curved = curved
+        if self._curved:
+            self.get_cached_table_curved_atmosphere()
+
+        else:
+            self._refractivity_integrated_table = np.zeros(len(self._heights))
+
+            self._refractivity_integrated_table[0] = self._refractivity_table[0] * self._height_increment
+            self._refractivity_integrated_table[1:] = self._refractivity_integrated_table[:-1] \
+                                                    + self._refractivity_table[1:] * self._height_increment
+
+    def get_cached_table_curved_atmosphere(self):
+        basedir = os.path.dirname(os.path.abspath(__file__))
+        fname = os.path.join(basedir, "refractivity_%02d_%.0f_%d.npz" % (self._atm_model,
+                self._refractivity_at_sea_level * 1e6, self._number_of_zenith_bins))
+
+        if os.path.exists(fname):
+            print("Read in {} ...".format(fname))
+            data = np.load(fname, "r")
+            self._refractivity_integrated_table = data["refractivity_integrated_table"]
+            self._distance_increment = data["distance_increment"]
+            self._distances = data["distances"]
+            self._zeniths = data["zeniths"]
+        else:
+            print("Write {} ...".format(fname))
+
+            self._distances = np.arange(-2e4, 3e5, self._distance_increment)
+            self._zeniths = np.hstack([np.arccos(1 / np.linspace(1.5557238268604123, 57.2986884985499, self._number_of_zenith_bins))])  # from 50 to 89 deg
+            self._refractivity_integrated_table = np.zeros((len(self._zeniths), len(self._distances)))
+
+            for zdx, zen in enumerate(self._zeniths):
+                for ddx, dist in enumerate(self._distances):
+                    height = atm.get_height_above_ground(dist, zen, observation_level=0)
+                    if height > np.amax(self._heights):
+                        sys.exit("Max height reached")
+                    refractivity = self.get_refractivity_for_height_tabulated(height)
+
+                    if ddx == 0:
+                        self._refractivity_integrated_table[zdx, 0] = refractivity * self._distance_increment
+                    else:
+                        self._refractivity_integrated_table[zdx, ddx] = \
+                                self._refractivity_integrated_table[zdx, ddx-1] \
+                                + refractivity * self._distance_increment
+
+            data = {"refractivity_integrated_table": self._refractivity_integrated_table,
+                    "distance_increment": self._distance_increment,
+                    "distances": self._distances,
+                    "zeniths": self._zeniths}
+
+            np.savez(fname, **data)
+
+
+    def get_refractivity_for_height_tabulated(self, h):
+        if h == 0:
+            return self._refractivity_at_sea_level
+
+        fidx = (h - self._heights[0]) / self._height_increment
+        idx = int(fidx)
+        f = fidx - idx
+
+        return (1-f) * self._refractivity_table[idx] + f * self._refractivity_table[idx+1]
+
+
+    def get_integrated_refractivity_for_height_tabulated(self, h):
+        # if self._curved:
+        #     sys.exit("Config is wrong: curved")
+
+        if h == 0:
+            return self._refractivity_at_sea_level
+
+        fidx = (h - self._heights[0]) / self._height_increment
+        idx = int(fidx)
+        f = fidx - idx
+
+        return (1-f) * self._refractivity_integrated_table[idx] + f * self._refractivity_integrated_table[idx+1]
+
+
+    def _get_integrated_refractivity_for_distance(self, d, zenith):
+        if not self._curved:
+            sys.exit("Config is wrong: not curved")
+
+        # next zenith bin. checks if zenith is in or out of range
+        zenith_idx = self.get_zenith_bin(zenith)
+
+        if d < np.amin(self._distances):
+            print(d, np.amin(self._distances))
+            sys.exit('_get_integrated_refractivity_for_distance: distance out of range')
+
+        distance_idx = (d - self._distances[0]) / self._distance_increment
+        idx = int(distance_idx)
+
+        # if distance is out of table
+        if not idx < len(self._distances) - 1:
+            slope10 = (self._refractivity_integrated_table[zenith_idx, -1] - \
+                       self._refractivity_integrated_table[zenith_idx, -10]) / 10
+            return self._refractivity_integrated_table[zenith_idx, -1] + slope10 * (distance_idx - len(self._distances))
+
+        f = distance_idx - idx
+        return (1 - f) * self._refractivity_integrated_table[zenith_idx, idx] \
+                + f * self._refractivity_integrated_table[zenith_idx, idx+1]
+
+
+    def get_zenith_bin(self, zenith):
+        if zenith < np.amin(self._zeniths) or zenith > np.amax(self._zeniths):
+            print("get_zenith_bin zenith out of range: {} not in [{}, {}]".format(*np.rad2deg([zenith,
+                                                                                     np.amin(self._zeniths),
+                                                                                     np.amax(self._zeniths)])))
+            raise ValueError
+        return np.argmin(np.abs(self._zeniths - zenith))
+
+
+    def get_integrated_refractivity_for_distance(self, d, zenith):
+        if not self._curved:
+            sys.exit("Config is wrong: not curved")
+
+        if not self._interpolate_zenith:
+            return self._get_integrated_refractivity_for_distance(d, zenith)
+
+        zenith_idx = self.get_zenith_bin(zenith)
+
+        if self._zeniths[zenith_idx] - zenith < 0:
+            bin_low, bin_up = zenith_idx, zenith_idx + 1
+        else:
+            bin_low, bin_up = zenith_idx - 1, zenith_idx
+
+        rlow = self._get_integrated_refractivity_for_distance(d, self._zeniths[bin_low])
+        rup = self._get_integrated_refractivity_for_distance(d, self._zeniths[bin_up])
+
+        if rlow < rup:
+            rinterp = rlow + (rup - rlow) / (self._zeniths[bin_up] - self._zeniths[bin_low]) * (zenith - self._zeniths[bin_low])
+        elif rup > rlow:
+            rinterp = rup + (rlow - rup) / (self._zeniths[bin_up] - self._zeniths[bin_low]) * (zenith - self._zeniths[bin_low])
+        else:
+            rinterp = rlow
+
+        return rinterp
+
+
+    def get_refractivity_between_two_points_from_distance(self, zenith, d1, d2):
+        r1 = self.get_integrated_refractivity_for_distance(d1, zenith=zenith)
+        r2 = self.get_integrated_refractivity_for_distance(d2, zenith=zenith)
+
+        return (r2 - r1) / (d2 - d1)
+
+
+    def get_refractivity_between_two_altitudes(self, h1, h2):
+        r1 = self.get_integrated_refractivity_for_height_tabulated(h1)
+        r2 = self.get_integrated_refractivity_for_height_tabulated(h2)
+
+        return (r2 - r1) / (h2 - h1)
+
+
+    def get_refractivity_between_two_points_tabulated(self, p1, p2):
+        dist = np.linalg.norm(p1 - p2)
+        zenith_local = helper.get_local_zenith_angle(p1, p2)
+        obs_level_local = helper.get_local_altitude(p2)
+
+        if zenith_local < np.amin(self._zeniths):
+            return self.get_refractivity_between_two_altitudes(obs_level_local, helper.get_local_altitude(p1))
+
+        zenith_at_earth, distance_to_earth = helper.get_zenith_angle_at_earth(zenith_local, obs_level_local)
+        d2 = dist + distance_to_earth
+
+        if zenith_at_earth < np.amin(self._zeniths):
+            return self.get_refractivity_between_two_altitudes(obs_level_local, helper.get_local_altitude(p1))
+
+        return self.get_refractivity_between_two_points_from_distance(zenith_at_earth, distance_to_earth, d2)
+
+
+    def get_refractivity_between_to_points_numerical(self, p1, p2, debug=False):
+        return get_refractivity_between_to_points_numerical(p1, p2, atmModel=self._atm_model,
+            n_asl=1+self._refractivity_at_sea_level, debug=debug)
+
+
+def get_refractivity_between_to_points_numerical(p1, p2, atmModel, n_asl, debug=False):
+
+    line = p1 - p2
+    max_dist = np.linalg.norm(line)
+    zenith = helper.get_local_zenith_angle(p1, p2)
+
+    nsteps = max(1000, min(int(max_dist / 100), 2001))
+    distances = np.linspace(0, max_dist, nsteps, endpoint=False)
+    obs_level = helper.get_local_altitude(p2)
+
+    dstep = distances[1] - distances[0]
+    refractivity = 0
+    for dist in distances:
+        height_asl = atm.get_height_above_ground(dist + dstep / 2, zenith, observation_level=obs_level) + obs_level
+        refractivity += (atm.get_n(height_asl, n0=n_asl, allow_negative_heights=False, model=atmModel) - 1) * dstep
+
+    if debug:
+        height_max = atm.get_height_above_ground(max_dist, zenith, observation_level=obs_level) + obs_level
+        print("calculate num for %.3f deg, %.1f m distance, %.1f m min height, %.1f m max height: N = %.3e" %
+             (np.rad2deg(zenith), max_dist, obs_level, height_max, refractivity / max_dist))
+
+    return refractivity / max_dist
+
+
+if __name__ == "__main__":
+    from matplotlib import pyplot as plt
+
+    from scipy import constants
+    from collections import defaultdict
+
+    tab = RefractivityTable(atm_model=27, interpolate_zenith=True, curved=True, number_of_zenith_bins=1000)
+    at = atm.Atmosphere(27)
+
+    data = defaultdict(list)
+
+    zeniths = np.deg2rad(np.arange(65, 86, 5))
+    depths = [400]
+    core = np.array([0, 0, 1400])
+
+    positions = np.array([np.linspace(-1000, 1000, 20), np.zeros(20), np.zeros(20)]).T + core
+    print(positions)
+    print(positions.shape)
+
+
+    for zenith in zeniths:
+        print('zenith', np.rad2deg(zenith))
+        shower_axis = helper.spherical_to_cartesian(zenith, 0)
+
+        for depth in depths:
+            dist = at.get_distance_xmax_geometric(zenith, depth, observation_level=core[-1])
+            if dist < 0:
+                continue
+
+            # sea level
+            point_on_axis = shower_axis * dist + core
+            point_on_axis_height = atm.get_height_above_ground(dist, zenith, observation_level=core[-1]) + core[-1]
+            print("Height of point in inital sys:", point_on_axis_height)
+
+            for pos in positions:
+                r_num = tab.get_refractivity_between_to_points_numerical(point_on_axis, pos, debug=False)
+                r_tab = tab.get_refractivity_between_two_points_tabulated(point_on_axis, pos)
+
+                zenith_eff = helper.get_local_zenith_angle(point_on_axis, pos)
+                obs_level_local = helper.get_local_altitude(pos)
+                pos_dist = np.linalg.norm(point_on_axis - pos)
+
+                data["r_num"].append(r_num)
+                data["r_tab"].append(r_tab)
+                data["distances"].append(pos_dist)
+                data["zenith_station"].append(zenith_eff)
+
+
+        data["zeniths"] += [zenith] * len(positions) * len(depths)
+
+    for key in data:
+        data[key] = np.array(data[key])
+
+    fig, axs = plt.subplots(2)
+
+    t_num = (data["distances"] / constants.c * (data["r_num"] + 1))
+    t_tab = (data["distances"] / constants.c * (data["r_tab"] + 1))
+
+    axs[0].plot(np.rad2deg(data["zenith_station"]), t_num * 1e6, "o", markersize=10, label="numerical")
+    axs[0].plot(np.rad2deg(data["zenith_station"]), t_tab * 1e6, "o", label="tabulated")
+    axs[0].set_ylabel(r"$t$ / $\mu$s")
+
+    axs[1].plot(np.rad2deg(data["zenith_station"]), (t_tab - t_num) * 1e9, "o")
+    axs[1].set_ylabel(r"$t_\mathrm{tab}$ - $t_\mathrm{num}$ / ns")
+
+
+    axs[0].legend()
+    axs[1].set_xlabel(r"zenith angle / deg")
+    plt.tight_layout()
+    plt.show()

--- a/radiotools/atmosphere/refractivity.py
+++ b/radiotools/atmosphere/refractivity.py
@@ -6,16 +6,113 @@ import sys
 import copy
 import os
 
+
+"""
+For the integrated refractivity from the table as function of the zenith angle and distance (curved is True) a minor,
+almost stable, bias of ~ 0.05 ns (propagated to propagation time) w.r.t. the numerical calculation is found. This is
+not found for the integrated refractivity from the table as function of height only. However this table assumes a flat
+atmosphere and thus loses accuracy for zenith angles beyond 60 - 70 deg.
+"""
+
+
 def n_param_ZHAireS(h):
+    """
+    Parametrisation for the refractivity N = n - 1, as funtion of height above sea level N(h) as used in ZHAireS.
+
+    Parameters
+    ------------
+    h : float
+        Height over sea level in meter
+
+    Returns
+    --------
+    refractivity : float
+        N(h)
+    """
+
     a = 325e-6
     b = 0.1218e-3
     return 1 + a * np.exp(-b * h)
 
 
+def get_refractivity_between_to_points_numerical(p1, p2, atm_model, refractivity_at_sea_level, debug=False):
+    """
+    Numerical calculation of the integrated refractivity between two positions along a straight line in the atmosphere.
+    Takes curvature of a spherical earth into account.
+    p1 and p2 need to be in the same coordiate system with the origin at sea level.
+
+    Parameters
+    ------------
+    p1 : array (3,)
+        coordinates in meter.
+    p2 : array (3,)
+        coordinates in meter.
+    atm_model : int
+        Number of the atmospheric model (from radiotools.atmosphere.models) which provides the desity profile rho(h)
+        to calculate the refractivity via N(h) = N(0) * rho(h) / rho(0).
+    refractivity_at_sea_level : float
+        Refractivity at earth surface, i.e., N(0) (default: 312e-6).
+    debug : bool
+        If True, prints out debug output (default: False).
+
+
+    Returns
+    --------
+    integrated refractivity : float
+    """
+    line = p1 - p2
+    max_dist = np.linalg.norm(line)
+    zenith = helper.get_local_zenith_angle(p1, p2)
+
+    nsteps = max(1000, min(int(max_dist / 100), 2001))
+    distances = np.linspace(0, max_dist, nsteps, endpoint=False)
+    obs_level = helper.get_local_altitude(p2)
+
+    dstep = distances[1] - distances[0]
+    refractivity = 0
+    for dist in distances:
+        height_asl = atm.get_height_above_ground(dist + dstep / 2, zenith, observation_level=obs_level) + obs_level
+        refractivity += (atm.get_n(height_asl, n0=refractivity_at_sea_level+1, allow_negative_heights=False,
+            model=atm_model) - 1) * dstep
+
+    if debug:
+        height_max = atm.get_height_above_ground(max_dist, zenith, observation_level=obs_level) + obs_level
+        print("calculate num for %.3f deg, %.1f m distance, %.1f m min height, %.1f m max height: N = %.3e" %
+             (np.rad2deg(zenith), max_dist, obs_level, height_max, refractivity / max_dist))
+
+    return refractivity / max_dist
+
+
 class RefractivityTable(object):
+    """
+    Class to calculate the integrated refractivity between two positions in the atmosphere.
+    """
+
 
     def __init__(self, atm_model=atm.default_model, param=False, refractivity_at_sea_level=312e-6, curved=False,
                  interpolate_zenith=True, number_of_zenith_bins=1000, distance_increment=100):
+
+        """
+        Parameters
+        ------------
+        atm_model : int
+            Number of the atmospheric model (from radiotools.atmosphere.models) which provides the desity profile rho(h)
+            to calculate the refractivity via N(h) = N(0) * rho(h) / rho(0) (Only if param is False).
+        param : bool
+            If True, uses ZHAireS parametrisation to calculate N(h) (default: False).
+        refractivity_at_sea_level : float
+            Refractivity at earth surface, i.e., N(0) (default: 312e-6).
+        curved : bool
+            If True, initializes tables for the integrated refractivity as function of zenith angle and distance.
+        interpolate_zenith : bool
+            If True, linear interpolation in zenith angle, if False, select closest zenith angle bin. Only relevant if
+            curved is True (default: True).
+        number_of_zenith_bins : int
+            Number of bins in theta(zenith). Only relevant if curved is True (default: 1000).
+        distance_increment : float
+            Bin size in distance in meter. Only relevant if curved is True (default: 100).
+
+        """
 
         self._distance_increment = distance_increment
         self._number_of_zenith_bins = number_of_zenith_bins
@@ -23,63 +120,72 @@ class RefractivityTable(object):
         self._refractivity_at_sea_level = refractivity_at_sea_level
         self._use_param = param
         self._atm_model = atm_model
-        self._rho0 = atm.get_density(0, allow_negative_heights=False, model=self._atm_model)
 
+        # set fix values.
+        self._min_zenith = np.deg2rad(50)
+        self._max_zenith = np.deg2rad(89)
         self._height_increment = 10
-        self._heights = np.arange(0, 2e5, self._height_increment)
-        self._refractivity_table = np.zeros(len(self._heights))
-        for hdx, height in enumerate(self._heights):
-            if self._use_param:
-                refractivity = n_param_ZHAireS(height) - 1
-            else:
-                refractivity = self._refractivity_at_sea_level * \
-                    atm.get_density(height, allow_negative_heights=True, model=self._atm_model) / self._rho0
+        self._max_heigth = 4e4
 
-            self._refractivity_table[hdx] = refractivity
+        self._heights = np.arange(0, self._max_heigth, self._height_increment)
+        rho0 = atm.get_density(0, allow_negative_heights=False, model=self._atm_model)
+        if self._use_param:
+            self._refractivity_table = np.array([n_param_ZHAireS(h) - 1 for h in self._heights])
+        else:
+            self._refractivity_table = np.array([self._refractivity_at_sea_level * \
+                atm.get_density(h, allow_negative_heights=True, model=self._atm_model) \
+                 / rho0 for h in self._heights])
+
+        self._refractivity_integrated_table_flat = np.cumsum(self._refractivity_table * self._height_increment)
 
         self._curved = curved
         if self._curved:
             self.get_cached_table_curved_atmosphere()
 
-        else:
-            self._refractivity_integrated_table = np.zeros(len(self._heights))
-
-            self._refractivity_integrated_table[0] = self._refractivity_table[0] * self._height_increment
-            self._refractivity_integrated_table[1:] = self._refractivity_integrated_table[:-1] \
-                                                    + self._refractivity_table[1:] * self._height_increment
+    def read_table_from_file(self, fname):
+        print("Read in {} ...".format(fname))
+        data = np.load(fname, "r", allow_pickle=True)
+        self._refractivity_integrated_table = data["refractivity_integrated_table"]
+        self._distance_increment = data["distance_increment"]
+        self._distances = data["distances"]
+        self._zeniths = data["zeniths"]
 
     def get_cached_table_curved_atmosphere(self):
+        """
+        Get table of integrated refractivity as function of zenith angle and distance. For curved atmosphere.
+        Will try to read table from numpy file if exsits and will write table to numpy file if it does not.
+        """
+
         basedir = os.path.dirname(os.path.abspath(__file__))
-        fname = os.path.join(basedir, "refractivity_%02d_%.0f_%d.npz" % (self._atm_model,
-                self._refractivity_at_sea_level * 1e6, self._number_of_zenith_bins))
+        fname = os.path.join(basedir, "refractivity_%02d_%.0f_%d_%d.npz" % (self._atm_model,
+                self._refractivity_at_sea_level * 1e6, self._number_of_zenith_bins, self._distance_increment))
 
         if os.path.exists(fname):
-            print("Read in {} ...".format(fname))
-            data = np.load(fname, "r")
-            self._refractivity_integrated_table = data["refractivity_integrated_table"]
-            self._distance_increment = data["distance_increment"]
-            self._distances = data["distances"]
-            self._zeniths = data["zeniths"]
+            self.read_table_from_file(fname)
+
         else:
             print("Write {} ...".format(fname))
 
-            self._distances = np.arange(0, 3e5, self._distance_increment)
-            self._zeniths = np.hstack([np.arccos(1 / np.linspace(1.5557238268604123, 57.2986884985499, self._number_of_zenith_bins))])  # from 50 to 89 deg
-            self._refractivity_integrated_table = np.zeros((len(self._zeniths), len(self._distances)))
+            # anchors for table binned in tan.
+            self._zeniths = np.arctan(np.linspace(np.tan(self._min_zenith), np.tan(self._max_zenith), self._number_of_zenith_bins))
+            self._distances = []
+            self._refractivity_integrated_table = []
 
             for zdx, zen in enumerate(self._zeniths):
-                for ddx, dist in enumerate(self._distances):
-                    height = atm.get_height_above_ground(dist, zen, observation_level=0)
-                    if height > np.amax(self._heights):
-                        sys.exit("Max height reached")
-                    refractivity = self.get_refractivity_for_height_tabulated(height)
+                max_dist = atm.get_distance_for_height_above_ground(self._max_heigth, zen, 0)
+                distances = np.arange(0, max_dist, self._distance_increment)
 
-                    if ddx == 0:
-                        self._refractivity_integrated_table[zdx, 0] = refractivity * self._distance_increment
-                    else:
-                        self._refractivity_integrated_table[zdx, ddx] = \
-                                self._refractivity_integrated_table[zdx, ddx-1] \
-                                + refractivity * self._distance_increment
+                # using d + self._distance_increment / 2 yield a slightly larger bias
+                refractivities_for_distances = np.array([self.get_refractivity_for_height_tabulated(
+                    atm.get_height_above_ground(d, zen, observation_level=0)) for d in distances])
+
+                refractivity_integrated_table = np.cumsum(refractivities_for_distances * self._distance_increment)
+
+                self._distances.append(distances)
+                self._refractivity_integrated_table.append(refractivity_integrated_table)
+
+            self._distances = np.array(self._distances)
+            self._refractivity_integrated_table = np.array(self._refractivity_integrated_table)
 
             data = {"refractivity_integrated_table": self._refractivity_integrated_table,
                     "distance_increment": self._distance_increment,
@@ -88,22 +194,32 @@ class RefractivityTable(object):
 
             np.savez(fname, **data)
 
-
     def get_refractivity_for_height_tabulated(self, h):
+        """
+            Get refractivity as function of height above ground from pre-calculated table.
+            Linear interpolation between table anchors.
+        """
+
         if h == 0:
             return self._refractivity_at_sea_level
 
         fidx = (h - self._heights[0]) / self._height_increment
         idx = int(fidx)
         f = fidx - idx
+
+        # if height is out of table (right edge): interpolate
+        if not idx < len(self._heights) - 1:
+            slope10 = (self._refractivity_table[-1] - self._refractivity_table[-10]) / 10
+            return self._refractivity_table[-1] + slope10 * (fidx - len(self._heights))
 
         return (1-f) * self._refractivity_table[idx] + f * self._refractivity_table[idx+1]
 
 
     def get_integrated_refractivity_for_height_tabulated(self, h):
-        # if self._curved:
-        #     sys.exit("Config is wrong: curved")
-
+        """
+            Get integrated refractivity as function of height above ground from pre-calculated table.
+            Linear interpolation between table anchors.
+        """
         if h == 0:
             return self._refractivity_at_sea_level
 
@@ -111,46 +227,63 @@ class RefractivityTable(object):
         idx = int(fidx)
         f = fidx - idx
 
-        return (1-f) * self._refractivity_integrated_table[idx] + f * self._refractivity_integrated_table[idx+1]
+        # if height is out of table (right edge): interpolate
+        if not idx < len(self._heights) - 1:
+            slope10 = (self._refractivity_integrated_table_flat[-1] - self._refractivity_integrated_table_flat[-10]) / 10
+            return self._refractivity_integrated_table_flat[-1] + slope10 * (fidx - len(self._heights))
+
+        return (1-f) * self._refractivity_integrated_table_flat[idx] + f * self._refractivity_integrated_table_flat[idx+1]
 
 
     def _get_integrated_refractivity_for_distance(self, d, zenith):
+        """
+            Get integrated refractivity as function of the zenith angle and distance from ground
+            (along a axis with the specified zenith angle) from pre-calculated table. Takes clostest zenith angle
+            from table to calculated the refractivity.
+        """
         if not self._curved:
-            sys.exit("Config is wrong: not curved")
+            sys.exit("Table not available: please specifiy \"curved=True\"")
 
         # next zenith bin. checks if zenith is in or out of range
         zenith_idx = self.get_zenith_bin(zenith)
 
-        if d < np.amin(self._distances):
-            print(d, np.amin(self._distances))
-            sys.exit('_get_integrated_refractivity_for_distance: distance out of range')
+        # if distance is out of table (left edge): fail
+        if d < np.amin(self._distances[zenith_idx]):
+            raise ValueError(r"Requested distance is out of range: {} ($\theta$ = {})".format(d, np.rad2deg(zenith)))
 
-        distance_idx = (d - self._distances[0]) / self._distance_increment
+        distance_idx = (d - self._distances[zenith_idx][0]) / self._distance_increment
         idx = int(distance_idx)
 
-        # if distance is out of table
-        if not idx < len(self._distances) - 1:
-            slope10 = (self._refractivity_integrated_table[zenith_idx, -1] - \
-                       self._refractivity_integrated_table[zenith_idx, -10]) / 10
-            return self._refractivity_integrated_table[zenith_idx, -1] + slope10 * (distance_idx - len(self._distances))
+        # if distance is out of table (right edge): interpolate
+        if not idx < len(self._distances[zenith_idx]) - 1:
+            slope10 = (self._refractivity_integrated_table[zenith_idx][-1] - \
+                       self._refractivity_integrated_table[zenith_idx][-10]) / 10
+            return self._refractivity_integrated_table[zenith_idx][-1] + slope10 * (distance_idx - len(self._distances[zenith_idx]))
 
         f = distance_idx - idx
-        return (1 - f) * self._refractivity_integrated_table[zenith_idx, idx] \
-                + f * self._refractivity_integrated_table[zenith_idx, idx+1]
+        return (1 - f) * self._refractivity_integrated_table[zenith_idx][idx] \
+                + f * self._refractivity_integrated_table[zenith_idx][idx+1]
 
 
     def get_zenith_bin(self, zenith):
+        """ get index of closest zenith bin """
+
         if zenith < np.amin(self._zeniths) or zenith > np.amax(self._zeniths):
-            print("get_zenith_bin zenith out of range: {} not in [{}, {}]".format(*np.rad2deg([zenith,
-                                                                                     np.amin(self._zeniths),
-                                                                                     np.amax(self._zeniths)])))
-            raise ValueError
+            raise ValueError("get_zenith_bin zenith out of range: {} not in [{}, {}]".format(*np.rad2deg([zenith,
+                             np.amin(self._zeniths), np.amax(self._zeniths)])))
+
         return np.argmin(np.abs(self._zeniths - zenith))
 
 
     def get_integrated_refractivity_for_distance(self, d, zenith):
+        """
+            Get integrated refractivity as function of the zenith angle and distance from ground
+            (along a axis with the specified zenith angle) from pre-calculated table. If "_interpolate_zenith" is True,
+            a linear interpolation in zenith angle is performed, otherwise the clostest zenith angle bin is used for the
+            calculation.
+        """
         if not self._curved:
-            sys.exit("Config is wrong: not curved")
+            sys.exit("Table not available: please specifiy \"curved=True\"")
 
         if not self._interpolate_zenith:
             return self._get_integrated_refractivity_for_distance(d, zenith)
@@ -176,6 +309,7 @@ class RefractivityTable(object):
 
 
     def get_refractivity_between_two_points_from_distance(self, zenith, d1, d2):
+        """ Get integrated refractivity along line (zenith) between two distances in curved atmosphere table """
         r1 = self.get_integrated_refractivity_for_distance(d1, zenith=zenith)
         r2 = self.get_integrated_refractivity_for_distance(d2, zenith=zenith)
 
@@ -183,6 +317,7 @@ class RefractivityTable(object):
 
 
     def get_refractivity_between_two_altitudes(self, h1, h2):
+        """ Get integrated refractivity between two altitudes in flat atmosphere table """
         r1 = self.get_integrated_refractivity_for_height_tabulated(h1)
         r2 = self.get_integrated_refractivity_for_height_tabulated(h2)
 
@@ -190,6 +325,11 @@ class RefractivityTable(object):
 
 
     def get_refractivity_between_two_points_tabulated(self, p1, p2):
+        """
+        Get integrated refractivity between two positions in curved atmosphere. If zenith angle out of table use
+        flat atmosphere
+        """
+
         dist = np.linalg.norm(p1 - p2)
         zenith_local = helper.get_local_zenith_angle(p1, p2)
         obs_level_local = helper.get_local_altitude(p2)
@@ -207,32 +347,9 @@ class RefractivityTable(object):
 
 
     def get_refractivity_between_to_points_numerical(self, p1, p2, debug=False):
-        return get_refractivity_between_to_points_numerical(p1, p2, atmModel=self._atm_model,
-            n_asl=1+self._refractivity_at_sea_level, debug=debug)
-
-
-def get_refractivity_between_to_points_numerical(p1, p2, atmModel, n_asl, debug=False):
-
-    line = p1 - p2
-    max_dist = np.linalg.norm(line)
-    zenith = helper.get_local_zenith_angle(p1, p2)
-
-    nsteps = max(1000, min(int(max_dist / 100), 2001))
-    distances = np.linspace(0, max_dist, nsteps, endpoint=False)
-    obs_level = helper.get_local_altitude(p2)
-
-    dstep = distances[1] - distances[0]
-    refractivity = 0
-    for dist in distances:
-        height_asl = atm.get_height_above_ground(dist + dstep / 2, zenith, observation_level=obs_level) + obs_level
-        refractivity += (atm.get_n(height_asl, n0=n_asl, allow_negative_heights=False, model=atmModel) - 1) * dstep
-
-    if debug:
-        height_max = atm.get_height_above_ground(max_dist, zenith, observation_level=obs_level) + obs_level
-        print("calculate num for %.3f deg, %.1f m distance, %.1f m min height, %.1f m max height: N = %.3e" %
-             (np.rad2deg(zenith), max_dist, obs_level, height_max, refractivity / max_dist))
-
-    return refractivity / max_dist
+        """ Get numerical calculated integrated refractivity between two positions in atmosphere """
+        return get_refractivity_between_to_points_numerical(p1, p2, atm_model=self._atm_model,
+            refractivity_at_sea_level=self._refractivity_at_sea_level, debug=debug)
 
 
 if __name__ == "__main__":
@@ -241,12 +358,13 @@ if __name__ == "__main__":
     from scipy import constants
     from collections import defaultdict
 
+    tab_flat = RefractivityTable(atm_model=27, curved=False, number_of_zenith_bins=1000)
     tab = RefractivityTable(atm_model=27, interpolate_zenith=True, curved=True, number_of_zenith_bins=1000)
     at = atm.Atmosphere(27)
 
     data = defaultdict(list)
 
-    zeniths = np.deg2rad(np.arange(65, 86, 5))
+    zeniths = np.deg2rad(np.arange(55, 80, 1))
     depths = [400]
     core = np.array([0, 0, 1400])
 
@@ -272,6 +390,7 @@ if __name__ == "__main__":
             for pos in positions:
                 r_num = tab.get_refractivity_between_to_points_numerical(point_on_axis, pos, debug=False)
                 r_tab = tab.get_refractivity_between_two_points_tabulated(point_on_axis, pos)
+                r_tab_flat = tab_flat.get_refractivity_between_two_altitudes(helper.get_local_altitude(pos), helper.get_local_altitude(point_on_axis))
 
                 zenith_eff = helper.get_local_zenith_angle(point_on_axis, pos)
                 obs_level_local = helper.get_local_altitude(pos)
@@ -279,6 +398,7 @@ if __name__ == "__main__":
 
                 data["r_num"].append(r_num)
                 data["r_tab"].append(r_tab)
+                data["r_tab_flat"].append(r_tab_flat)
                 data["distances"].append(pos_dist)
                 data["zenith_station"].append(zenith_eff)
 
@@ -292,13 +412,19 @@ if __name__ == "__main__":
 
     t_num = (data["distances"] / constants.c * (data["r_num"] + 1))
     t_tab = (data["distances"] / constants.c * (data["r_tab"] + 1))
+    t_tab_flat = (data["distances"] / constants.c * (data["r_tab_flat"] + 1))
+    t_uni = (data["distances"] / constants.c)
 
-    axs[0].plot(np.rad2deg(data["zenith_station"]), t_num * 1e6, "o", markersize=10, label="numerical")
-    axs[0].plot(np.rad2deg(data["zenith_station"]), t_tab * 1e6, "o", label="tabulated")
+    axs[0].plot(np.rad2deg(data["zenith_station"]), t_num * 1e6, "C0o", markersize=10, label="numerical")
+    axs[0].plot(np.rad2deg(data["zenith_station"]), t_tab * 1e6, "C1o", label="tabulated")
+    axs[0].plot(np.rad2deg(data["zenith_station"]), t_tab_flat * 1e6, "C2o", label="tabulated flat")
+    axs[0].plot(np.rad2deg(data["zenith_station"]), t_uni * 1e6, "C3o", label="unity")
     axs[0].set_ylabel(r"$t$ / $\mu$s")
 
-    axs[1].plot(np.rad2deg(data["zenith_station"]), (t_tab - t_num) * 1e9, "o")
-    axs[1].set_ylabel(r"$t_\mathrm{tab}$ - $t_\mathrm{num}$ / ns")
+    axs[1].plot(np.rad2deg(data["zenith_station"]), (t_tab - t_num) * 1e9, "C1o", label="tabulated")
+    axs[1].plot(np.rad2deg(data["zenith_station"]), (t_tab_flat - t_num) * 1e9, "C2o", label="tabulated flat")
+    axs[1].plot(np.rad2deg(data["zenith_station"]), (t_uni - t_num) * 1e9, "C3o", label="unity")
+    axs[1].set_ylabel(r"$t_\mathrm{i}$ - $t_\mathrm{num}$ / ns")
 
 
     axs[0].legend()

--- a/radiotools/atmosphere/refractivity.py
+++ b/radiotools/atmosphere/refractivity.py
@@ -63,7 +63,7 @@ class RefractivityTable(object):
         else:
             print("Write {} ...".format(fname))
 
-            self._distances = np.arange(-2e4, 3e5, self._distance_increment)
+            self._distances = np.arange(0, 3e5, self._distance_increment)
             self._zeniths = np.hstack([np.arccos(1 / np.linspace(1.5557238268604123, 57.2986884985499, self._number_of_zenith_bins))])  # from 50 to 89 deg
             self._refractivity_integrated_table = np.zeros((len(self._zeniths), len(self._distances)))
 

--- a/radiotools/atmosphere/refractivity.py
+++ b/radiotools/atmosphere/refractivity.py
@@ -35,7 +35,7 @@ def n_param_ZHAireS(h):
     return 1 + a * np.exp(-b * h)
 
 
-def get_refractivity_between_to_points_numerical(p1, p2, atm_model, refractivity_at_sea_level, debug=False):
+def get_refractivity_between_two_points_numerical(p1, p2, atm_model, refractivity_at_sea_level, debug=False):
     """
     Numerical calculation of the integrated refractivity between two positions along a straight line in the atmosphere.
     Takes curvature of a spherical earth into account.
@@ -346,9 +346,9 @@ class RefractivityTable(object):
         return self.get_refractivity_between_two_points_from_distance(zenith_at_earth, distance_to_earth, d2)
 
 
-    def get_refractivity_between_to_points_numerical(self, p1, p2, debug=False):
+    def get_refractivity_between_two_points_numerical(self, p1, p2, debug=False):
         """ Get numerical calculated integrated refractivity between two positions in atmosphere """
-        return get_refractivity_between_to_points_numerical(p1, p2, atm_model=self._atm_model,
+        return get_refractivity_between_two_points_numerical(p1, p2, atm_model=self._atm_model,
             refractivity_at_sea_level=self._refractivity_at_sea_level, debug=debug)
 
 
@@ -388,7 +388,7 @@ if __name__ == "__main__":
             print("Height of point in inital sys:", point_on_axis_height)
 
             for pos in positions:
-                r_num = tab.get_refractivity_between_to_points_numerical(point_on_axis, pos, debug=False)
+                r_num = tab.get_refractivity_between_two_points_numerical(point_on_axis, pos, debug=False)
                 r_tab = tab.get_refractivity_between_two_points_tabulated(point_on_axis, pos)
                 r_tab_flat = tab_flat.get_refractivity_between_two_altitudes(helper.get_local_altitude(pos), helper.get_local_altitude(point_on_axis))
 

--- a/tests/tests_refractivity.py
+++ b/tests/tests_refractivity.py
@@ -1,0 +1,44 @@
+from __future__ import print_function
+from past.builtins import xrange
+
+from radiotools.atmosphere import refractivity
+from radiotools import helper
+import unittest
+import numpy as np
+
+axis = helper.spherical_to_cartesian(np.deg2rad(80), 0)
+tab_flat = refractivity.RefractivityTable(27)
+tab_curved = refractivity.RefractivityTable(27, curved=True, number_of_zenith_bins=100)
+
+class RefractivityTests(unittest.TestCase):
+
+    def test_compare_tabs_for_flat_table(self):
+        heights = np.arange(0, 5e4, 1e3)
+        for height in heights:
+            self.assertTrue(np.allclose(tab_flat.get_integrated_refractivity_for_height_tabulated(height),
+                                        tab_curved.get_integrated_refractivity_for_height_tabulated(height)))
+
+    def test_curved_table(self):
+        refractivities = []
+        for dist in np.arange(1e3, 1e5, 1e4):
+            point = axis * dist
+            r = tab_curved.get_refractivity_between_two_points_tabulated(point, np.array([0, 0, 0]))
+            refractivities.append(r)
+
+        self.assertTrue(np.allclose(refractivities, np.array([0.00030889595670082067, 0.000282411093234063, 0.000258794023252093,
+            0.00023771311586077572, 0.0002188753498864094, 0.0002020187326970188, 0.0001865660513275855, 0.0001719832852117586,
+            0.00015860798388484651, 0.00014650532450181743])))
+
+    def test_num_cal(self):
+        refractivities = []
+        for dist in np.arange(1e3, 1e5, 1e4):
+            point = axis * dist
+            r = tab_curved.get_refractivity_between_to_points_numerical(point, np.array([0, 0, 0]))
+            refractivities.append(r)
+        self.assertTrue(np.allclose(refractivities, np.array([0.00030917724719699887, 0.000282667441765032, 0.0002590260410419691,
+            0.00023792193761338818, 0.00021906244225125651, 0.00020218896167550733, 0.0001867273146300562, 0.00017212383567359824,
+            0.0001587301696693485, 0.00014661389359611995])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tests_refractivity.py
+++ b/tests/tests_refractivity.py
@@ -33,7 +33,7 @@ class RefractivityTests(unittest.TestCase):
         refractivities = []
         for dist in np.arange(1e3, 1e5, 1e4):
             point = axis * dist
-            r = tab_curved.get_refractivity_between_to_points_numerical(point, np.array([0, 0, 0]))
+            r = tab_curved.get_refractivity_between_two_points_numerical(point, np.array([0, 0, 0]))
             refractivities.append(r)
         self.assertTrue(np.allclose(refractivities, np.array([0.00030917724719699887, 0.000282667441765032, 0.0002590260410419691,
             0.00023792193761338818, 0.00021906244225125651, 0.00020218896167550733, 0.0001867273146300562, 0.00017212383567359824,


### PR DESCRIPTION
…d refractivity for straight lines in curved geometries using pre-calculated tables. Assumes a spherical earth.

The tables are anchored at the earths surface. For a given source and receiver the local zenith at the surface of the earth is calculated and along this line the refractivity is calculated. 

With the default value of 1000 zenith bins some features in the residual remain. With 10000 they vanish however the table takes quite long to initialize.

The comparison with the numerical calculation reveals some bias which is zenith angle dependent. However this is well below 0.1ns in light propagation time and thus not really import. Also within one event the introduced bias is very small.  

