### PR TITLE
Fix model calculation include obs lvl

### DIFF
--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -356,6 +356,7 @@ class Atmosphere():
                 print("all constants calculated, exiting now... please rerun your analysis")
                 sys.exit(0)
 
+
     def __calculate_a(self,):
         zeniths = np.arccos(np.linspace(0, 1, self.number_of_zeniths))
         a = np.zeros((self.number_of_zeniths, 5))
@@ -368,6 +369,7 @@ class Atmosphere():
 
         return a
 
+
     def __get_a(self, zenith):
         a = np.zeros(5)
         b = self.b
@@ -379,6 +381,7 @@ class Atmosphere():
         a[3] = self._get_atmosphere_numeric([zenith], h_low=h[3]) - b[3] * np.exp(-h[3] / c[3]) * self._get_dldh(h[3], zenith, 3)
         a[4] = self._get_atmosphere_numeric([zenith], h_low=h[4]) + b[4] * h[4] / c[4] * self._get_dldh(h[4], zenith, 4)
         return a
+
 
     def _get_dldh(self, h, zenith, iH):
         if iH < 4:
@@ -426,6 +429,7 @@ class Atmosphere():
 
         return dldh
 
+
     def __get_method_mask(self, zenith):
         if not self.curved:
             return np.ones_like(zenith, dtype=np.bool), np.zeros_like(zenith, dtype=np.bool), np.zeros_like(zenith, dtype=np.bool)
@@ -433,6 +437,7 @@ class Atmosphere():
         mask_taylor = zenith < self.__zenith_numeric
         mask_numeric = zenith >= self.__zenith_numeric
         return mask_flat, mask_taylor, mask_numeric
+
 
     def __get_height_masks(self, hh):
         # mask0 = (hh >= 0) & (hh < atm_models[self.model]['h'][0])
@@ -443,6 +448,7 @@ class Atmosphere():
         mask4 = (hh >= atm_models[self.model]['h'][3]) & (hh < h_max)
         mask5 = hh >= h_max
         return np.array([mask0, mask1, mask2, mask3, mask4, mask5])
+
 
     def __get_X_masks(self, X, zenith):
         mask0 = X > self._get_atmosphere(zenith, atm_models[self.model]['h'][0])
@@ -457,48 +463,56 @@ class Atmosphere():
         mask5 = X <= 0
         return np.array([mask0, mask1, mask2, mask3, mask4, mask5])
 
+
     def __get_arguments(self, mask, *args):
-        tmp = []
-        ones = np.ones(np.array(mask).size)
-        for a in args:
-            if np.shape(a) == ():
-                tmp.append(a * ones)
-            else:
-                tmp.append(a[mask])
-        return tmp
+        ones = np.ones(np.sum(mask))
+        return [a * ones if np.shape(a) == () else a[mask] for a in args]
+
 
     def get_atmosphere(self, zenith, h_low=0., h_up=np.infty, observation_level=0):
         """ returns the atmosphere for an air shower with given zenith angle (in g/cm^2) """
         return self._get_atmosphere(zenith, h_low=h_low, h_up=h_up, observation_level=observation_level) * 1e-4
 
+
     def _get_atmosphere(self, zenith, h_low=0., h_up=np.infty, observation_level=0):
         mask_flat, mask_taylor, mask_numeric = self.__get_method_mask(zenith)
-        mask_finite = np.array((h_up * np.ones_like(zenith)) < h_max)
-        is_mask_finite = np.sum(mask_finite)
+        
+        mask_h2_finite = np.array((h_up * np.ones_like(zenith)) < h_max)
+        is_mask_h2_finite = np.any(mask_h2_finite)
+        
+        atmosphere_h1_to_h2 = np.zeros_like(zenith)
+        if np.any(mask_numeric):
+            atmosphere_h1_to_h2[mask_numeric] = self._get_atmosphere_numeric(
+                *self.__get_arguments(mask_numeric, zenith, h_low, h_up, observation_level))
 
-        tmp = np.zeros_like(zenith)
-        if np.sum(mask_numeric):
-            # print("getting numeric")
-            tmp[mask_numeric] = self._get_atmosphere_numeric(*self.__get_arguments(mask_numeric, zenith, h_low, h_up, observation_level))
+        if np.any(mask_taylor):
+            atmosphere_h1_to_inf = self._get_atmosphere_taylor(
+                *self.__get_arguments(mask_taylor, zenith, h_low))
+            
+            atmosphere_h2_to_inf = np.zeros_like(atmosphere_h1_to_inf)
+            if(is_mask_h2_finite):
+                mask_tmp = np.squeeze(mask_h2_finite[mask_taylor])
+                atmosphere_h2_to_inf[mask_tmp] = self._get_atmosphere_taylor(
+                    *self.__get_arguments(mask_tmp, zenith, h_up))
 
-        if np.sum(mask_taylor):
-            # print("getting taylor")
-            tmp[mask_taylor] = self._get_atmosphere_taylor(*self.__get_arguments(mask_taylor, zenith, h_low))
-            if(is_mask_finite):
-                # print("\t is finite")
-                mask_tmp = np.squeeze(mask_finite[mask_taylor])
-                tmp2 = self._get_atmosphere_taylor(*self.__get_arguments(mask_taylor, zenith, h_up))
-                tmp[mask_tmp] = tmp[mask_tmp] - np.array(tmp2)
+            atmosphere_h1_to_h2[mask_taylor] = atmosphere_h1_to_inf - \
+                atmosphere_h2_to_inf
 
-        if np.sum(mask_flat):
-            # print("getting flat atm")
-            tmp[mask_flat] = self._get_atmosphere_flat(*self.__get_arguments(mask_flat, zenith, h_low))
-            if(is_mask_finite):
-                mask_tmp = np.squeeze(mask_finite[mask_flat])
-                tmp2 = self._get_atmosphere_flat(*self.__get_arguments(mask_flat, zenith, h_up))
-                tmp[mask_tmp] = tmp[mask_tmp] - np.array(tmp2)
+        if np.any(mask_flat):
+            atmosphere_h1_to_inf = self._get_atmosphere_flat(
+                *self.__get_arguments(mask_flat, zenith, h_low))
+            
+            atmosphere_h2_to_inf = np.zeros_like(atmosphere_h1_to_inf)
+            if(is_mask_h2_finite):
+                mask_tmp = np.squeeze(mask_h2_finite[mask_flat])
+                atmosphere_h2_to_inf = self._get_atmosphere_flat(
+                    *self.__get_arguments(mask_tmp, zenith, h_up))
 
-        return tmp
+            atmosphere_h1_to_h2[mask_flat] = atmosphere_h1_to_inf - \
+                atmosphere_h2_to_inf
+
+        return atmosphere_h1_to_h2
+
 
     def __get_a_from_interpolation(self, zeniths):
         a = np.zeros((len(zeniths), 5))
@@ -556,6 +570,7 @@ class Atmosphere():
                     tmp[mask] = np.zeros(np.sum(mask))
         return tmp
 
+
     def _get_atmosphere_numeric(self, zenith, h_low=0, h_up=np.infty, observation_level=0):
         zenith = np.array(zenith)
         tmp = np.zeros_like(zenith)
@@ -580,15 +595,18 @@ class Atmosphere():
             d_low = get_distance_for_height_above_ground(t_h_low - o, z, o)
             d_up = get_distance_for_height_above_ground(t_h_up - o, z, o)
 
-            full_atm = integrate.quad(self._get_density_for_distance, d_low, d_up, args=(z, o), limit=500)[0]
+            full_atm = integrate.quad(self._get_density_for_distance, d_low, d_up, 
+                                      args=(z, o), epsabs=1.49e-08, epsrel=1.49e-08, limit=500)[0]
 
             tmp[i] = full_atm
 
         return tmp
 
+
     def _get_atmosphere_flat(self, zenith, h=0):
         y = _get_atmosphere(h, model=self.model)
         return y / np.cos(zenith)
+
 
     def get_vertical_height(self, zenith, xmax):
         """ returns the (vertical) height above see level [in meters] as a function
@@ -596,20 +614,26 @@ class Atmosphere():
         """
         return self._get_vertical_height(zenith, xmax * 1e4)
 
+
     def _get_vertical_height(self, zenith, X):
         mask_flat, mask_taylor, mask_numeric = self.__get_method_mask(zenith)
         tmp = np.zeros_like(zenith)
-        # print(zenith, X)
+
         if np.sum(mask_numeric):
             print("get vertical height numeric", zenith)
-            tmp[mask_numeric] = self._get_vertical_height_numeric(*self.__get_arguments(mask_numeric, zenith, X))
+            tmp[mask_numeric] = self._get_vertical_height_numeric(
+                *self.__get_arguments(mask_numeric, zenith, X))
+
         if np.sum(mask_taylor):
-            tmp[mask_taylor] = self._get_vertical_height_numeric_taylor(*self.__get_arguments(mask_taylor, zenith, X))
+            tmp[mask_taylor] = self._get_vertical_height_numeric_taylor(
+                *self.__get_arguments(mask_taylor, zenith, X))
+
         if np.sum(mask_flat):
             print("get vertical height flat")
             tmp[mask_flat] = self._get_vertical_height_flat(*self.__get_arguments(mask_flat, zenith, X))
-        # print(tmp)
+
         return tmp
+
 
     def _get_vertical_height_numeric(self, zenith, X):
         height = np.zeros_like(zenith)
@@ -631,6 +655,7 @@ class Atmosphere():
             height[i] = get_height_above_ground(dxmax_geo, zenith[i], observation_level=0)
 
         return height
+
 
     def _get_vertical_height_numeric_taylor(self, zenith, X):
         height = np.zeros_like(zenith)
@@ -656,6 +681,7 @@ class Atmosphere():
 
         return height
 
+
     def _get_vertical_height_flat(self, zenith, X):
         return _get_vertical_height(X * np.cos(zenith), model=self.model)
 
@@ -664,6 +690,7 @@ class Atmosphere():
         and shower maximum Xmax (in g/cm^2) """
         return self._get_density(zenith, xmax * 1e4)
 
+
     def _get_density(self, zenith, xmax):
         """ returns the atmospheric density as a function of zenith angle
         and shower maximum Xmax """
@@ -671,9 +698,11 @@ class Atmosphere():
         rho = get_density(h, model=self.model)
         return rho
 
+
     def _get_density_for_distance(self, d, zenith, observation_level=0):
         h = get_height_above_ground(d, zenith, observation_level) + observation_level
         return get_density(h, model=self.model)
+
 
     def get_distance_xmax(self, zenith, xmax, observation_level=1564.):
         """ input:
@@ -683,6 +712,7 @@ class Atmosphere():
         """
         dxmax = self._get_distance_xmax(zenith, xmax * 1e4, observation_level=observation_level)
         return dxmax * 1e-4
+
 
     def _get_distance_xmax(self, zenith, xmax, observation_level=1564.):
         return self._get_atmosphere(zenith, h_low=observation_level) - xmax
@@ -696,9 +726,11 @@ class Atmosphere():
         return self._get_distance_xmax_geometric(zenith, xmax * 1e4,
                                                  observation_level=observation_level)
 
+
     def _get_distance_xmax_geometric(self, zenith, xmax, observation_level=1564.):
         h = self._get_vertical_height(zenith, xmax) - observation_level
         return get_distance_for_height_above_ground(h, zenith, observation_level)
+
 
     def get_xmax_from_distance(self, distance, zenith, observation_level=1564.):
         """ input:
@@ -709,6 +741,7 @@ class Atmosphere():
         h_xmax = get_height_above_ground(distance, zenith, observation_level) + observation_level
         return self.get_atmosphere(zenith, h_low=observation_level) - \
                self.get_atmosphere(zenith, h_low=observation_level, h_up=h_xmax)
+
 
     def get_viewing_angle(self, zenith, r, xmax=600, observation_level=1564.):
         """
@@ -728,6 +761,7 @@ class Atmosphere():
         dxmax = self.get_distance_xmax_geometric(zenith, xmax, observation_level)
         return np.arctan(r / dxmax)
 
+
     def get_radial_distane_from_viewing_angle(self, zenith, viewing_angle, xmax=600, observation_level=1564.):
         """
         calculates the radial distance from the observer position (defined by xmax and the viewing angle) to the shower
@@ -745,17 +779,3 @@ class Atmosphere():
         """
         dxmax = self.get_distance_xmax_geometric(zenith, xmax, observation_level)
         return dxmax * np.tan(viewing_angle)
-
-#     def __get_distance_xmax_geometric_flat(self, xmax, observation_level=1564.):
-# #         _get_vertical_height(xmax, self.model)
-# #         dxmax = self._get_distance_xmax(xmax, observation_level=observation_level)
-# #         txmax = _get_atmosphere(observation_level, model=self.model) - dxmax * np.cos(self.zenith)
-#         return height / np.cos(self.zenith)
-
-#         full = _get_atmosphere(observation_level, model=self.model) / np.cos(self.zenith)
-
-# def get_distance_xmax_geometric2(xmax, zenith, observation_level=1564.,
-#                                 model=1, curved=False):
-#     """ input:
-
-#     def get_atmosphere3(self, h_low=0., h_up=np.infty):

--- a/radiotools/helper.py
+++ b/radiotools/helper.py
@@ -161,7 +161,7 @@ def get_intersection_between_circle_and_line(r, b, c):
         return x0 + b * mult, y0 - a * mult, x0 - b * mult, y0 + a * mult
 
 
-def get_zenith_angle_at_earth(zenith, observer_level):
+def get_zenith_angle_at_sea_level(zenith, observer_level):
     """
     Calculates intersections of a line with an anchor at an observation level and zenith angle with a spherical earth.
     Determines distance along line between clostest intersection and the observation level and local zenith angle at that
@@ -181,6 +181,10 @@ def get_zenith_angle_at_earth(zenith, observer_level):
     distance : float
         distance between found intersection and observation level in meter
     """
+
+    if observer_level == 0:
+        return zenith, 0
+
     r_e = atm.r_e
     coors = get_intersection_between_circle_and_line(r_e, -np.tan(zenith), (r_e + observer_level) * np.tan(zenith))
 


### PR DESCRIPTION
Hi, this branch is not jet ready to be merged but needs some discussion. This PR picks up #38 and issue #41. 

Briefly: 
Functions like get_vertical_height, get_distance_xmax, etc which take a zenith angle as input calculate the height, grammage, etc for a point in space. This point in space in only properly defined with a observation level which defines the inclination, i.e., zenith angle.

I ran some cross-checks on this. Compare to the result provided bei CORSIKA/CoREAS. The improvement is not significant (it was already good before). 

The plots below show shower with zenith angle between 65 and 85 binned in 2.5deg steps.


With the "bug"
![dmax_comparison_rt_corsika_xmax_bug](https://user-images.githubusercontent.com/30903175/114182034-7d0fa280-9942-11eb-82be-4bf61f10e948.png)

With "bug" fixed for numerical calculation (applied for zenith angle > 80 deg, default)
![dmax_comparison_rt_corsika_xmax_bug_fix](https://user-images.githubusercontent.com/30903175/114182031-7d0fa280-9942-11eb-84ef-c087aa38f9e8.png)

With "bug" fixed for numerical calculation (applied for all zenith angle)
![dmax_comparison_rt_corsika_xmax_bug_fix_num](https://user-images.githubusercontent.com/30903175/114182025-7bde7580-9942-11eb-9af9-71e6e871f971.png)

