### PR TITLE
Replace past.builtins.xrange with range for compatability with Python3.11

### DIFF
--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -1,6 +1,5 @@
 # Python 2 and 3: backward-compatible
 from __future__ import absolute_import, division, print_function  # , unicode_literals
-from past.builtins import xrange
 
 from scipy import optimize, interpolate, integrate
 
@@ -484,7 +483,7 @@ class Atmosphere():
 
                 zeniths = np.arccos(np.linspace(0, 1, self.number_of_zeniths))
                 mask = zeniths < np.deg2rad(90)
-                self.a_funcs = [interpolate.interp1d(zeniths[mask], self.a[..., i][mask], kind='cubic') for i in xrange(5)]
+                self.a_funcs = [interpolate.interp1d(zeniths[mask], self.a[..., i][mask], kind='cubic') for i in range(5)]
 
             else:
                 self.a = self.__calculate_a()
@@ -680,7 +679,7 @@ class Atmosphere():
 
     def __get_a_from_interpolation(self, zeniths):
         a = np.zeros((len(zeniths), 5))
-        for i in xrange(5):
+        for i in range(5):
             a[..., i] = self.a_funcs[i](zeniths)
         return a
 
@@ -702,7 +701,7 @@ class Atmosphere():
         ax.legend()
         plt.tight_layout()
 
-        for i in xrange(5):
+        for i in range(5):
             y = self.a[..., i][mask]
             f2 = interpolate.interp1d(x, y, kind='cubic')
             xxx = np.linspace(0, 81, 100)
@@ -745,7 +744,7 @@ class Atmosphere():
         zenith = np.array(zenith)
         tmp = np.zeros_like(zenith)
 
-        for i in xrange(len(tmp)):
+        for i in range(len(tmp)):
 
             t_h_low = h_low if np.array(h_low).size == 1 else h_low[i]
             t_h_up = h_up if np.array(h_up).size == 1 else h_up[i]
@@ -818,7 +817,7 @@ class Atmosphere():
             dtmp = tmp - xmax
             return dtmp
 
-        for i in xrange(len(height)):
+        for i in range(len(height)):
             x0 = get_distance_for_height_above_ground(self._get_vertical_height_flat(zenith[i], X[i]), zenith[i])
 
             # finding root e.g., distance for given xmax (when difference is 0)
@@ -843,7 +842,7 @@ class Atmosphere():
             dtmp = tmp - xmax
             return dtmp
 
-        for i in xrange(len(height)):
+        for i in range(len(height)):
             if(X[i] < 0):
                 X[i] = 0
 

--- a/radiotools/coreas/generate_coreas_sim.py
+++ b/radiotools/coreas/generate_coreas_sim.py
@@ -4,7 +4,6 @@ import stat
 import numpy as np
 from radiotools import coordinatesystems
 from radiotools import helper as hp
-from past.builtins import xrange
 
 # $_CONDOR_SCRATCH_DIR
 
@@ -242,7 +241,7 @@ def write_list_star_pattern(filename, zen, az, append=False, obs_level=1564.0, o
                 slices = np.array(slices)
                 if(slicing_method == "distance"):
                     slices *= 100
-                for iSlice in xrange(len(slices) - 1):
+                for iSlice in range(len(slices) - 1):
                     name = "pos_%i_%i_slice%i" % (rs[i], np.rad2deg(azimuths[j]), iSlice)
                     if gammacut is None:
                         fout.write('AntennaPosition = {0} {1} {2} {3} {4} {5} {6}\n'.format(x, y, z, name, slicing_method, slices[iSlice] * 100., slices[iSlice + 1] * 100.))
@@ -310,7 +309,7 @@ def write_list_star_pattern(filename, zen, az, append=False, obs_level=1564.0, o
 #                     slices = np.array(slices)
 #                     if(slicing_method == "distance"):
 #                         slices *= 100
-#                     for iSlice in xrange(len(slices) - 1):
+#                     for iSlice in range(len(slices) - 1):
 #                         fout.write('AntennaPosition = {0} {1} {2} {3} {4} {5} {6}\n'.format(x, y, z, name, slicing_method, slices[iSlice] * 100., slices[iSlice + 1] * 100.))
 #     fout.close()
 

--- a/tests/tests_atmosphere.py
+++ b/tests/tests_atmosphere.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from past.builtins import xrange
 
 from radiotools.atmosphere import models as atmos
 
@@ -41,13 +40,13 @@ class AtmosphereTests(unittest.TestCase):
         heights = np.linspace(0, 1e4, 10)
         atm1 = atm.get_atmosphere(zeniths, heights)
         atm2 = atm.get_atmosphere(np.zeros(10), heights) / np.cos(zeniths)
-        for i in xrange(len(atm1)):
+        for i in range(len(atm1)):
             self.assertAlmostEqual(atm1[i], atm2[i])
 
         heights2 = np.linspace(1e4, 1e5, 10)
         atm1 = atm.get_atmosphere(zeniths, heights, heights2)
         atm2 = atm.get_atmosphere(np.zeros(10), heights, heights2) / np.cos(zeniths)
-        for i in xrange(len(atm1)):
+        for i in range(len(atm1)):
             self.assertAlmostEqual(atm1[i], atm2[i])
 
         z = np.deg2rad(50)
@@ -65,19 +64,19 @@ class AtmosphereTests(unittest.TestCase):
         zeniths = np.deg2rad(np.linspace(0, 20, 3))
         atm1 = atm_flat.get_atmosphere(zeniths, 0)
         atm2 = atm_num.get_atmosphere(zeniths, 0)
-        for i in xrange(len(atm1)):
+        for i in range(len(atm1)):
             delta = 1e-3 + np.rad2deg(zeniths[i]) * 1e-2
             self.assertAlmostEqual(atm1[i], atm2[i], delta=delta)
 
         atm1 = atm_flat.get_atmosphere(zeniths, 1e3)
         atm2 = atm_num.get_atmosphere(zeniths, 1e3)
-        for i in xrange(len(atm1)):
+        for i in range(len(atm1)):
             delta = 1e-3 + np.rad2deg(zeniths[i]) * 1e-2
             self.assertAlmostEqual(atm1[i], atm2[i], delta=delta)
 
         atm1 = atm_flat.get_atmosphere(zeniths, 1e3, 1e4)
         atm2 = atm_num.get_atmosphere(zeniths, 1e3, 1e4)
-        for i in xrange(len(atm1)):
+        for i in range(len(atm1)):
             delta = 1e-3 + np.rad2deg(zeniths[i]) * 1e-2
             self.assertAlmostEqual(atm1[i], atm2[i], delta=delta)
 
@@ -100,7 +99,7 @@ class AtmosphereTests(unittest.TestCase):
             self.assertAlmostEqual(atm1, atm2, delta=1e-3)
 
         zeniths = np.deg2rad([0, 11.478341, 30.683417])
-        for i in xrange(len(zeniths)):
+        for i in range(len(zeniths)):
             delta = 1e-6
             atm1 = atm_taylor.get_atmosphere(zeniths[i], 0)
             atm2 = atm_num.get_atmosphere(zeniths[i], 0)
@@ -108,13 +107,13 @@ class AtmosphereTests(unittest.TestCase):
 
         atm1 = atm_taylor.get_atmosphere(zeniths, 1e3)
         atm2 = atm_num.get_atmosphere(zeniths, 1e3)
-        for i in xrange(len(atm1)):
+        for i in range(len(atm1)):
             delta = 1e-5
             self.assertAlmostEqual(atm1[i], atm2[i], delta=delta)
 
         atm1 = atm_taylor.get_atmosphere(zeniths, 1e3, 1e4)
         atm2 = atm_num.get_atmosphere(zeniths, 1e3, 1e4)
-        for i in xrange(len(atm1)):
+        for i in range(len(atm1)):
             delta = 1e-5
             self.assertAlmostEqual(atm1[i], atm2[i], delta=delta)
 
@@ -132,7 +131,7 @@ class AtmosphereTests(unittest.TestCase):
         atm_num = atmos.Atmosphere(curved=True, zenith_numeric=0)
 
         zeniths = np.deg2rad(np.linspace(0, 83, 20))
-        for i in xrange(len(zeniths)):
+        for i in range(len(zeniths)):
             delta = 1e-3
             # print "checking z = %.1f" % np.rad2deg(zeniths[i])
             atm1 = atm_taylor.get_atmosphere(zeniths[i], 0)
@@ -141,7 +140,7 @@ class AtmosphereTests(unittest.TestCase):
             self.assertAlmostEqual(atm1, atm2, delta=delta)
 
         zeniths = np.deg2rad(np.linspace(0, 83, 20))
-        for i in xrange(len(zeniths)):
+        for i in range(len(zeniths)):
             delta = 1e-2
             # print "checking z = %.1f" % np.rad2deg(zeniths[i])
             atm1 = atm_taylor.get_atmosphere(zeniths[i], 1e3)
@@ -149,7 +148,7 @@ class AtmosphereTests(unittest.TestCase):
             self.assertAlmostEqual(atm1, atm2, delta=delta)
 
         zeniths = np.deg2rad(np.linspace(0, 83, 20))
-        for i in xrange(len(zeniths)):
+        for i in range(len(zeniths)):
             delta = 1e-2
             # print "checking z = %.1f" % np.rad2deg(zeniths[i])
             atm1 = atm_taylor.get_atmosphere(zeniths[i], 0, 1e4)
@@ -163,14 +162,14 @@ class AtmosphereTests(unittest.TestCase):
         xmax = np.linspace(300, 900, 20)
         atm1 = atm_flat.get_vertical_height(zenith * np.ones_like(xmax), xmax)
         atm2 = atm_num.get_vertical_height(zenith * np.ones_like(xmax), xmax)
-        for i in xrange(len(xmax)):
+        for i in range(len(xmax)):
             self.assertAlmostEqual(atm1[i], atm2[i], delta=1e-2)
 
         zeniths = np.deg2rad(np.linspace(0, 30, 4))
         xmax = 600
         atm1 = atm_flat.get_vertical_height(zeniths, xmax)
         atm2 = atm_num.get_vertical_height(zeniths, xmax)
-        for i in xrange(len(zeniths)):
+        for i in range(len(zeniths)):
             self.assertAlmostEqual(atm1[i], atm2[i], delta=1e-3 * atm1[i])
 
     def test_vertical_height_taylor_numeric(self):
@@ -183,7 +182,7 @@ class AtmosphereTests(unittest.TestCase):
         atm1 = atm_taylor.get_vertical_height(zeniths, xmax)
         atm2 = atm_num.get_vertical_height(zeniths, xmax)
 
-        for i in xrange(len(zeniths)):
+        for i in range(len(zeniths)):
             self.assertAlmostEqual(atm1[i], atm2[i], delta=2e-5 * atm1[i])
 
 #

--- a/tests/tests_refractivity.py
+++ b/tests/tests_refractivity.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from past.builtins import xrange
 
 from radiotools.atmosphere import refractivity
 from radiotools import helper


### PR DESCRIPTION
Solves #57

radiotools uses `xrange`, which needed to be imported from `past.builtins.xrange` since it is not available in Python3.

I've replaced `xrange` with `range`, which behaves like the old Python2 implementation of `xrange`. For Python2, `range` will now actually built the whole list instead of a generator, which is less memory efficient, but I hope this shouldn't be too big of a problem.

EDIT: See also the discussion in #22

