### PR TITLE
Fixing RefractivityTable class

### DIFF
--- a/radiotools/atmosphere/refractivity.py
+++ b/radiotools/atmosphere/refractivity.py
@@ -231,8 +231,8 @@ class RefractivityTable(object):
                 self._distances.append(distances)
                 self._refractivity_integrated_table.append(refractivity_integrated_table)
 
-            self._distances = np.array(self._distances)
-            self._refractivity_integrated_table = np.array(self._refractivity_integrated_table)
+            self._distances = np.array(self._distances, dtype=object)
+            self._refractivity_integrated_table = np.array(self._refractivity_integrated_table, dtype=object)
 
             data = {"refractivity_integrated_table": self._refractivity_integrated_table,
                     "distance_increment": self._distance_increment,

--- a/radiotools/helper.py
+++ b/radiotools/helper.py
@@ -267,8 +267,13 @@ def get_angle(v1, v2):
     Returns: float or list of floats
         angle(s) between vector(s)
     """
-
-    arccos = np.dot(v1, v2) / (np.linalg.norm(v1.T, axis=0) * np.linalg.norm(v2.T, axis=0))
+    
+    if v1.ndim == 2 and v2.ndim == 2:
+        arccos = np.array([
+            np.dot(v1_, v2_) / (np.linalg.norm(v1_.T, axis=0) * np.linalg.norm(v2_.T, axis=0))
+            for v1_, v2_ in zip(v1, v2)])
+    else:
+        arccos = np.dot(v1, v2) / (np.linalg.norm(v1.T, axis=0) * np.linalg.norm(v2.T, axis=0))
     # catch numerical overlow
     mask1 = arccos > 1
     mask2 = arccos < -1


### PR DESCRIPTION
To create an 2d inhomogenous array we need to specify the type to be `object`.

I do not know why this was not necessary earlier. My best guess is that it became an error with a higher python/numpy version.