### PR TITLE
Fix bug in `get_xmax_from_distance` for curved geometries. Improve doc-string of `get_atmosphere`

### DIFF
--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -968,14 +968,6 @@ class Atmosphere():
         h_xmax = get_height_above_ground(distance, zenith, observation_level) + observation_level
         return self.get_atmosphere(zenith, h_low=observation_level, observation_level=observation_level) - \
             self.get_atmosphere(zenith, h_low=observation_level, h_up=h_xmax, observation_level=observation_level)
-        """ input:
-            - distance to xmax in m
-            - zenith in radians
-            output: xmax g/cm^2
-        """
-        h_xmax = get_height_above_ground(distance, zenith, observation_level) + observation_level
-        return self.get_atmosphere(zenith, h_low=observation_level) - \
-               self.get_atmosphere(zenith, h_low=observation_level, h_up=h_xmax)
 
 
     def get_viewing_angle(self, zenith, r, xmax=600, observation_level=1564.):

--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -921,6 +921,27 @@ class Atmosphere():
 
 
     def get_xmax_from_distance(self, distance, zenith, observation_level=1564.):
+        """
+        Returns the slant depth (i.e., Xmax) for a point along a (shower) axis defined
+        by the zenith angle and the distance to the point and observation level.
+
+        Parameters
+        ----------
+        distance: float
+            Distance to the point in m
+        zenith: float
+            Zenith angle in radians
+        observation_level: float
+            Observation level in m
+
+        Returns
+        -------
+        xmax : float
+            Xmax in g/cm^2
+        """
+        h_xmax = get_height_above_ground(distance, zenith, observation_level) + observation_level
+        return self.get_atmosphere(zenith, h_low=observation_level, observation_level=observation_level) - \
+            self.get_atmosphere(zenith, h_low=observation_level, h_up=h_xmax, observation_level=observation_level)
         """ input:
             - distance to xmax in m
             - zenith in radians

--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -643,7 +643,33 @@ class Atmosphere():
 
 
     def get_atmosphere(self, zenith, h_low=0., h_up=np.inf, observation_level=0):
-        """ returns the atmosphere for an air shower with given zenith angle (in g/cm^2) """
+        """
+        Returns the atmosphere between the altitude `h_low` and `h_up` along a line (shower axis)
+        with a given zenith angle.
+
+        NOTE: It is important to note that the atmosphere is always integrated between `h_low` and `h_up`.
+        Even if the `obsrvation_level` is non zero! The observation level is only used to interprete
+        the zenith angle at this height in a curved atmosphere. In a flat atmosphere the observation level has
+        no effect on the result what so ever.
+
+        Parameters
+        ----------
+        zenith: float or array
+            Zenith angle in radians.
+        h_low: float or array (Default: 0.)
+            Lower bound to integrate over the atmosphere in meter. Relative to sea level.
+        h_up: float or array (Default: np.inf)
+            Upper bound to integrate over the atmosphere in meter. Relative to sea level.
+        observation_level: float or array (Default: 0)
+            Height of the observation level above sea level in meter. The zenith angle is interpreted at this height.
+            However, the atmosphere is integrated from `h_low` to `h_up`.
+
+        Returns
+        -------
+        atm: float or array
+            Amount of atmosphere between `h_low` and `h_up` in g/cm^2.
+
+        """
         return self._get_atmosphere(zenith, h_low=h_low, h_up=h_up, observation_level=observation_level) * 1e-4
 
 

--- a/tests/tests_atmosphere.py
+++ b/tests/tests_atmosphere.py
@@ -23,6 +23,12 @@ class AtmosphereTests(unittest.TestCase):
         self.assertFalse(np.allclose(dxmax_1564, dxmax_3000, rtol=0.1, atol=100))
 
 
+    def test_distance_xmax_round_trip(self):
+        atm = atmos.Atmosphere()
+        zeniths = np.deg2rad(np.linspace(0, 85, 30))
+        dX = np.array([750 - atm.get_xmax_from_distance(atm.get_distance_xmax_geometric(z, 750, 1400), z, 1400) for z in zeniths])
+        self.assertFalse(np.allclose(dX, np.zeros_like(dX)))
+
     def test_height_above_ground_to_distance_transformation(self):
         zeniths = np.deg2rad(np.linspace(0, 90, 10))
         for zenith in zeniths:


### PR DESCRIPTION
This PR fixes a bug in `get_xmax_from_distance` which only occurs for curved geometries and is only relevant for inclined air showers. 

When calculating `Xmax` from the geometrical distance to Xmax `dmax` for experiments with a non zero observation hight this bug change the `Xmax` values. The following plot shows by how much for the US std atmosphere.

![image](https://github.com/user-attachments/assets/3f34c264-db6d-44a4-9e26-e709a83f30c0)
