### PR TITLE
Replace print statements with logger in several files

### DIFF
--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -839,7 +839,7 @@ class Atmosphere():
         tmp = np.zeros_like(zenith)
 
         if np.sum(mask_numeric):
-            # logger.info("get vertical height numeric", zenith)
+            logger.debug("get vertical height numeric {0}".format(zenith))
             tmp[mask_numeric] = self._get_vertical_height_numeric(
                 *self.__get_arguments(mask_numeric, zenith, X), observation_level=observation_level)
 
@@ -848,7 +848,7 @@ class Atmosphere():
                 *self.__get_arguments(mask_taylor, zenith, X), observation_level=observation_level)
 
         if np.sum(mask_flat):
-            # logger.info("get vertical height flat")
+            logger.debug("get vertical height flat")
             tmp[mask_flat] = self._get_vertical_height_flat(*self.__get_arguments(mask_flat, zenith, X))
 
         return tmp

--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -468,7 +468,7 @@ class Atmosphere():
         self.number_of_zeniths = number_of_zeniths
 
         if gdas_file is None:
-            logger.info("model is ", model)
+            logger.info("model is %s", model)
             self.model = model
             self.n0 = n0
             self._is_gdas = False
@@ -493,9 +493,9 @@ class Atmosphere():
                 filename = os.path.join(
                     folder, "constants_%s_%i.npz" % (checksum, n_taylor))
 
-            logger.info("searching constants at ", filename)
+            logger.info("searching constants at %s", filename)
             if os.path.exists(filename):
-                logger.debug("reading constants from ", filename)
+                logger.debug("reading constants from %s", filename)
 
                 with np.load(filename, "rb") as fin:
                     self.a = fin["a"]
@@ -552,7 +552,8 @@ class Atmosphere():
         for iZ, z in enumerate(zeniths):
             logger.info("calculating constants for %.02f deg zenith angle (iZ = %i, nT = %i)..." % (np.rad2deg(z), iZ, self.n_taylor))
             a[iZ] = self.__get_a(z)
-            logger.debug("\t... a  = ", a[iZ], " iZ = ", iZ)
+            logger.debug("\t... a  = %s", a[iZ]) 
+            logger.debug(" iZ = %s", iZ)
 
         return a
 

--- a/radiotools/atmosphere/refractivity.py
+++ b/radiotools/atmosphere/refractivity.py
@@ -39,7 +39,7 @@ def n_param_ZHAireS(h):
     return 1 + a * np.exp(-b * h)
 
 
-def get_refractivity_between_two_points_numerical(p1, p2, atm_model=None, refractivity_at_sea_level=None, table=None):
+def get_refractivity_between_two_points_numerical(p1, p2, atm_model=None, refractivity_at_sea_level=None, table=None, debug=None):
     """
     Numerical calculation of the integrated refractivity between two positions along a straight line in the atmosphere.
     Takes curvature of a spherical earth into account.
@@ -68,6 +68,13 @@ def get_refractivity_between_two_points_numerical(p1, p2, atm_model=None, refrac
     integrated_refractivity : float
         Refractive index integrated along a straight line between two given points
     """
+    if debug is not None:
+        logger.warning(
+            "The debug parameter of get_refractivity_between_two_points_numerical has been deprecated. "
+            "Please use the logger functionality instead. "
+            "For your convenience, I will now set the logging level of radiotools to DEBUG."
+        )
+        logger.setLevel(logging.DEBUG)
 
     if table is None and (atm_model is None and refractivity_at_sea_level is None):
         sys.exit("Invalid arguments. You have to specify table or atm_model and refractivity_at_sea_level.")
@@ -417,9 +424,9 @@ class RefractivityTable(object):
         return self.get_refractivity_between_two_points_from_distance(zenith_at_sea_level, distance_to_earth, d2)
 
 
-    def get_refractivity_between_two_points_numerical(self, p1, p2):
+    def get_refractivity_between_two_points_numerical(self, p1, p2, debug=None):
         """ Get numerical calculated integrated refractivity between two positions in atmosphere """
-        return get_refractivity_between_two_points_numerical(p1, p2, table=self)
+        return get_refractivity_between_two_points_numerical(p1, p2, table=self, debug=debug)
 
 
 if __name__ == "__main__":

--- a/radiotools/atmosphere/refractivity.py
+++ b/radiotools/atmosphere/refractivity.py
@@ -445,7 +445,7 @@ if __name__ == "__main__":
 
 
     for zenith in zeniths:
-        logger.debug('zenith', np.rad2deg(zenith))
+        logger.debug('zenith = %s', np.rad2deg(zenith))
         shower_axis = helper.spherical_to_cartesian(zenith, 0)
 
         for depth in depths:
@@ -456,7 +456,7 @@ if __name__ == "__main__":
             # sea level
             point_on_axis = shower_axis * dist + core
             point_on_axis_height = atm.get_height_above_ground(dist, zenith, observation_level=core[-1]) + core[-1]
-            logger.info("Height of point in inital sys:", point_on_axis_height)
+            logger.info("Height of point in inital sys: %s", point_on_axis_height)
 
             for pos in positions:
                 r_num = tab.get_refractivity_between_two_points_numerical(point_on_axis, pos)

--- a/radiotools/atmosphere/refractivity.py
+++ b/radiotools/atmosphere/refractivity.py
@@ -417,9 +417,9 @@ class RefractivityTable(object):
         return self.get_refractivity_between_two_points_from_distance(zenith_at_sea_level, distance_to_earth, d2)
 
 
-    def get_refractivity_between_two_points_numerical(self, p1, p2, debug=False):
+    def get_refractivity_between_two_points_numerical(self, p1, p2):
         """ Get numerical calculated integrated refractivity between two positions in atmosphere """
-        return get_refractivity_between_two_points_numerical(p1, p2, table=self, debug=debug)
+        return get_refractivity_between_two_points_numerical(p1, p2, table=self)
 
 
 if __name__ == "__main__":
@@ -459,7 +459,7 @@ if __name__ == "__main__":
             logger.info("Height of point in inital sys:", point_on_axis_height)
 
             for pos in positions:
-                r_num = tab.get_refractivity_between_two_points_numerical(point_on_axis, pos, debug=False)
+                r_num = tab.get_refractivity_between_two_points_numerical(point_on_axis, pos)
                 r_tab = tab.get_refractivity_between_two_points_tabulated(point_on_axis, pos)
                 r_tab_flat = tab_flat.get_refractivity_between_two_altitudes(
                     helper.get_local_altitude(pos), helper.get_local_altitude(point_on_axis))

--- a/radiotools/helper.py
+++ b/radiotools/helper.py
@@ -568,8 +568,8 @@ def get_2d_probability(x, y, xx, yy, xx_error, yy_error, xy_correlation, sigma=F
     if sigma:
         from scipy.stats import chi2, norm
         # p = norm.cdf(i) - norm.cdf(-i)
-        logger.debug("p = ", nom, denom, nom / denom, "sigma =", chi2.ppf(nom / denom, 1))
-        logger.debug("p = ", p)
+        logger.debug("p = %s %s %s sigma = %s" % (nom, denom, nom / denom,  chi2.ppf(nom / denom, 1)))
+        logger.debug("p = %s", p)
         logger.debug(norm.ppf(nom / denom))
         return chi2.ppf(nom / denom, 1)
     else:

--- a/radiotools/helper.py
+++ b/radiotools/helper.py
@@ -5,6 +5,10 @@ import numpy as np
 import sys
 from scipy.signal import correlate
 
+import logging
+
+logger = logging.getLogger('radiotools.helper')
+
 
 def linear_to_dB(linear):
     """ conversion to decibel scale
@@ -436,7 +440,7 @@ def get_interval_hilbert(trace, scale=0.5):
     elif (d == 2):
         h = np.sqrt(np.sum(np.abs(hilbert(trace)) ** 2, axis=0))
     else:
-        print("ERROR, trace has not the correct dimension")
+        logger.error("trace has not the correct dimension")
         raise
     return get_interval(h, scale)
 
@@ -486,7 +490,7 @@ def get_angle_to_efieldexpectation_in_showerplane(efield, core, zenith, azimuth,
         difference is evaluated in the showerfront, components not perpendicular to
         the shower axis are thus neglected. """
     if (efield.shape != stationPositions.shape):
-        print("ERROR: shape of efield and station positions is not the same.")
+        logger.error("shape of efield and station positions is not the same.")
         raise
     from CSTransformation import CSTransformation
 
@@ -564,9 +568,9 @@ def get_2d_probability(x, y, xx, yy, xx_error, yy_error, xy_correlation, sigma=F
     if sigma:
         from scipy.stats import chi2, norm
         # p = norm.cdf(i) - norm.cdf(-i)
-        print("p = ", nom, denom, nom / denom, "sigma =", chi2.ppf(nom / denom, 1))
-        print("p = ", p)
-        print(norm.ppf(nom / denom))
+        logger.debug("p = ", nom, denom, nom / denom, "sigma =", chi2.ppf(nom / denom, 1))
+        logger.debug("p = ", p)
+        logger.debug(norm.ppf(nom / denom))
         return chi2.ppf(nom / denom, 1)
     else:
         return nom / denom


### PR DESCRIPTION
In my work I use the `Atmosphere` class often. Every time I create one, there is a "model is ..." print statement which is cluttering my output. Therefore I replaced all print statements in `models.py` with logger calls.