### PR TITLE
Fix get_n() in Atmosphere

### DIFF
--- a/radiotools/__init__.py
+++ b/radiotools/__init__.py
@@ -1,5 +1,3 @@
-
-
 """A tool package for cosmic-ray and neutrino radio detectors."""
 
-__version__ = '0.2.3'
+__version__ = "0.2.4"

--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -514,12 +514,12 @@ class Atmosphere():
 
     def get_n(self, h):
         if self._is_gdas:
-            idx = np.argmin(np.abs(self.n_h[:, 0] - h))
             if h < self.n_h[0, 0]:
                 return self.n_h[0, 1]
             elif h > self.n_h[-1, 0]:
                 return self.n_h[-1, 1]
 
+            idx = np.argmin(np.abs(self.n_h[:, 0] - h))
             if self.n_h[idx, 0] < h:
                 return self.n_h[idx, 1] + (self.n_h[idx+1, 1] - self.n_h[idx, 1]) / (self.n_h[idx+1, 0] - self.n_h[idx, 0]) * (h - self.n_h[idx, 0])
             else:

--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -515,9 +515,9 @@ class Atmosphere():
     def get_n(self, h):
         if self._is_gdas:
             idx = np.argmin(np.abs(self.n_h[:, 0] - h))
-            if idx == 0:
+            if h < self.n_h[0, 0]:
                 return self.n_h[0, 1]
-            elif idx == len(self.n_h) - 1:
+            elif h > self.n_h[-1, 0]:
                 return self.n_h[-1, 1]
 
             if self.n_h[idx, 0] < h:

--- a/radiotools/atmosphere/models.py
+++ b/radiotools/atmosphere/models.py
@@ -517,7 +517,7 @@ class Atmosphere():
             idx = np.argmin(np.abs(self.n_h[:, 0] - h))
             if idx == 0:
                 return self.n_h[0, 1]
-            elif idx == len(self.n_h):
+            elif idx == len(self.n_h) - 1:
                 return self.n_h[-1, 1]
 
             if self.n_h[idx, 0] < h:


### PR DESCRIPTION
The `get_n()` function of the Atmosphere class had a bug which triggers when using a GDAS atmosphere. The result of an `np.argmin()` call is never equal to the length of the array, but at most `len() - 1`. Since this was not caught properly, a crash would occur when actually requesting a height above the last element of the array, because it would try to access the `[idx + 1]` element which does not exist.

I also increased the version number in `__init__.py` to release a new version on PyPi with this bugfix.